### PR TITLE
fixing equal number fight probability

### DIFF
--- a/simulator.go
+++ b/simulator.go
@@ -48,9 +48,6 @@ func simulateHumanFight(E1, E2 int) (survivor int, victory bool) {
 
 // getProba reimplements the getProba logic from Board.cs in the C# implementation
 func getProba(E1, E2 int, involveHumans bool) float64 {
-	if E1 == E2 {
-		return 0.5
-	}
 	var cste float64
 	if involveHumans {
 		cste = 1

--- a/simulator.go
+++ b/simulator.go
@@ -72,6 +72,6 @@ func getProba(E1, E2 int, involveHumans bool) float64 {
 		y0 = 1
 		m := (y0 - y1) / (x0 - x1)
 		c := 1 - m*x0
-		return m*float64(E2) + c
+		return m*float64(E1) + c
 	}
 }


### PR DESCRIPTION
* Succo's server didn't respect the rule if there were the same amount of humans and monsters.
* Also, there was a big typo in the probability computing.

Here's the official server code snippet for proof
```
            double x0, y0, x1 = attackedcount, y1 = 0.5;

            if (attackercount < attackedcount)
            {
                //détail pour maintenance
                x0 = 0;
                y0 = 0;

                return (y0 - y1) / (x0 - x1) * attackercount;
            }
            else
            {
                //détail pour maintenance
                //cste utilisé dans le cas où on changerait les règles...
                x0 = cste * attackedcount;
                y0 = 1;
                double
                    m = (y0 - y1) / (x0 - x1),
                    c = 1 - m * x0;
                return m * attackercount + c;
            }
```